### PR TITLE
refactor: feedをconfigで追加できるようにリファクタリング

### DIFF
--- a/.tmp/pr-5-body.md
+++ b/.tmp/pr-5-body.md
@@ -1,0 +1,99 @@
+**PR タイトル案**
+- feat: GitHub Changelog の RSS を追加して要約・Discord 通知に対応
+
+**概要**
+- GitHub Changelog の RSS フィードを新規購読して、既存の AWS / Martin Fowler と同様に要約＆Discord 通知まで流すようにした。
+  これにより、GitHub の変更情報（Changelog）も自動でキャッチできる。
+
+**背景**
+- 要望: https://github.blog/changelog/feed/ を購読対象に追加したい（“購入”ではなく“購読”）。
+- 既存は AWS と Martin Fowler の2本。運用フローは維持しつつ3本目のソースを追加。
+
+**変更点**
+- 取得: `src/services/rss-fetcher.ts`
+  - `fetchGitHubChangelogFeed()` を追加（RSS 2.0）。
+  - `fetchAllFeeds()` を AWS / Martin Fowler / GitHub Changelog の3本並列に拡張。
+  - パース失敗時のエラーメッセージを一般化（RSS/Atom で共通化）。
+- 処理: `src/handlers/cron.ts`
+  - `github_changelog` の記事も保存・Discord 通知対象に追加。
+  - 完了ログに `githubChangelogArticles` を追加。
+- 型: `src/types/index.ts`
+  - `Article.feed_source` と `ArticleFilter.source` に `'github_changelog'` を追加。
+- 通知: `src/services/discord-notifier.ts`
+  - `github_changelog` のカラー（GitHub Purple: `0x6e5494`）と表示名「GitHub Changelog」を追加。
+- デバッグ: `scripts/debug-summary.ts`
+  - GitHub Changelog 記事も要約テスト対象に追加。
+- ユーティリティ: `scripts/discord-test.ts` を追加（Webhook 通知の単体テスト用）。
+  - `package.json` に `discord:test` スクリプトを追加。
+- テスト: 既存テストの文言調整＋GitHub Changelog 追加分を網羅し、全テストをパス。
+
+**実装詳細**
+- 追加 Feed URL: https://github.blog/changelog/feed/
+- `feed_source` 値: `github_changelog`
+- パース:
+  - RSS 2.0: `title`, `link`, `pubDate`, `description` を取り出し。
+  - Atom: 既存（Martin Fowler 用）実装を流用。
+- 保存ポリシー: URL 重複チェック → 未保存なら D1 `articles` に Insert → Discord 通知。
+- Discord 埋め込み:
+  - フッター: 「GitHub Changelog」。
+  - カラー: `0x6e5494`。
+  - タイムスタンプ: 記事の公開日時（不正な場合は現在時刻）。
+
+**動作確認**
+- ローカル起動: `npm run dev`。
+- 手動実行（要トークン）:
+  - `.dev.vars` に `ADMIN_TOKEN` を設定。
+  - `curl -H "Authorization: Bearer $ADMIN_TOKEN" -X POST http://127.0.0.1:8787/api/cron/update-feeds`。
+  - 期待: 新規記事があれば D1 に保存され、Discord に順次通知される。
+- Discord Webhook 単体テスト:
+  - `.dev.vars` に `DISCORD_WEBHOOK_URL` を設定。
+  - `bun run scripts/discord-test.ts`（または `npm run discord:test`）。
+  - 期待: 「テスト通知 - Discord連携確認」が Discord に届く。
+- デバッグ要約テスト:
+  - `GEMINI_API_KEY` を設定。
+  - `bun run scripts/debug-summary.ts`。
+  - 期待: 3ソース（AWS / Martin / GitHub）から1件ずつ拾って要約・通知。
+
+**テスト結果**
+- 実行: `bun test`。
+- 結果: 69 pass / 0 fail。
+- カバレッジ（参考）:
+  - `src/services/rss-fetcher.ts`: Lines 100%。
+  - `src/handlers/cron.ts`: Lines ~85%。
+  - 主要ファイルは既存水準を維持。
+
+**影響範囲**
+- DB: マイグレーション不要（`feed_source` は TEXT）。
+- 型: `feed_source` のユニオン拡張あり。外部参照があれば `'github_changelog'` を追加扱いに調整が必要。
+- ログ: 完了ログに GitHub 件数を追加（運用可視化に有用）。
+
+**リスクと対策**
+- 新規 RSS のXML差異: 失敗時は当該ソースのみ空配列にフォールバック（他ソースは継続）。
+- Discord Rate Limit: 既存の 100ms ウェイトを維持。
+- 要約失敗: 保存・通知は継続（`summary_ja` は未設定で保存）。
+
+**デプロイ手順**
+- 機密はWranglerの`secret/vars`に設定：
+  - `wrangler secret put DISCORD_WEBHOOK_URL`
+  - `wrangler secret put GEMINI_API_KEY`
+  - `wrangler secret put ADMIN_TOKEN`
+- デプロイ: `npm run deploy`。
+
+**ロールバック**
+- 早期停止: `fetchAllFeeds()` から `fetchGitHubChangelogFeed()` 呼び出しを一時除外。
+- 完全撤回: `feed_source = 'github_changelog'` の記事を手動削除。
+
+**関連**
+- Issue: 必要なら追記（例: `Closes #<issue-number>`）。
+
+**スクリーンショット／ログ**
+- Discord テスト通知: 「テスト通知 - Discord連携確認」を実送信して成功を確認済み。
+- Cron 完了ログ: `processedCount`, `newArticlesCount`, `errorCount`, `awsArticles`, `martinfowlerArticles`, `githubChangelogArticles` を出力。
+
+**チェックリスト**
+- [x] コード: TypeScript `strict` 準拠
+- [x] テスト: `bun test` パス
+- [x] Lint: `npm run lint`
+- [x] 型検査: `npm run type-check`
+- [x] 機密情報のコミットなし（`.dev.vars` のみローカル）
+- [x] PR 説明に検証手順とエンドポイントを記載

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -1,0 +1,45 @@
+export type FeedFormat = 'rss' | 'atom' | 'auto';
+
+export interface FeedDefinition {
+  id: string;
+  url: string;
+  format: FeedFormat;
+  displayName: string;
+  color: number;
+  enabled?: boolean;
+}
+
+// 追加したいブログはこの配列にエントリを1つ足すだけ
+export const FEEDS = [
+  {
+    id: 'aws',
+    url: 'https://aws.amazon.com/about-aws/whats-new/recent/feed/',
+    format: 'rss',
+    displayName: 'AWS ニュース',
+    color: 0x3498db,
+    enabled: true,
+  },
+  {
+    id: 'martinfowler',
+    url: 'https://martinfowler.com/feed.atom',
+    format: 'atom',
+    displayName: 'Martin Fowler',
+    color: 0x2ecc71,
+    enabled: true,
+  },
+  {
+    id: 'github_changelog',
+    url: 'https://github.blog/changelog/feed/',
+    format: 'rss',
+    displayName: 'GitHub Changelog',
+    color: 0x6e5494,
+    enabled: true,
+  },
+] as const satisfies ReadonlyArray<FeedDefinition>;
+
+export type FeedSource = typeof FEEDS[number]['id'];
+
+export function getFeedById(id: string): FeedDefinition | undefined {
+  return (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === id);
+}
+

--- a/src/services/discord-notifier.ts
+++ b/src/services/discord-notifier.ts
@@ -1,5 +1,6 @@
 import type { Article } from '../types';
 import { Logger } from './logger';
+import { getFeedById } from '../config/feeds';
 
 interface DiscordWebhookPayload {
   embeds: Array<{
@@ -97,29 +98,13 @@ export class DiscordNotifier {
   }
 
   private getFeedColor(feedSource: string): number {
-    switch (feedSource) {
-      case 'aws':
-        return 0x3498db; // 青
-      case 'martinfowler':
-        return 0x2ecc71; // 緑
-      case 'github_changelog':
-        return 0x6e5494; // GitHub Purple
-      default:
-        return 0x95a5a6; // グレー
-    }
+    const def = getFeedById(feedSource);
+    return def?.color ?? 0x95a5a6; // デフォルトはグレー
   }
 
   private getFeedDisplayName(feedSource: string): string {
-    switch (feedSource) {
-      case 'aws':
-        return 'AWS ニュース';
-      case 'martinfowler':
-        return 'Martin Fowler';
-      case 'github_changelog':
-        return 'GitHub Changelog';
-      default:
-        return feedSource;
-    }
+    const def = getFeedById(feedSource);
+    return def?.displayName ?? feedSource;
   }
 
   private delay(ms: number): Promise<void> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,11 @@
+import type { FeedSource } from '../config/feeds';
+
 export interface Article {
   id: number;
   title: string;
   url: string;
   published_date: string;
-  feed_source: 'aws' | 'martinfowler' | 'github_changelog';
+  feed_source: FeedSource;
   original_content?: string;
   summary_ja?: string;
   created_at: string;
@@ -42,7 +44,7 @@ export interface Environment {
 }
 
 export interface ArticleFilter {
-  source?: 'aws' | 'martinfowler' | 'github_changelog' | 'all';
+  source?: FeedSource | 'all';
   page?: number;
   limit?: number;
 }


### PR DESCRIPTION
## 目的

フィード拡張を前提に、個別実装を排し「設定駆動」でスケールする構成へリファクタリングしたよ。新しいブログを追加するときにコード改修を不要にして、保守性・可読性・テスト容易性を一気に上げたのがゴールだよ。

## 変更概要

- 設定一元化: `src/config/feeds.ts` を新規追加
  - `id`/`url`/`format(rss|atom|auto)`/`displayName`/`color`/`enabled` を定義
  - 1行追加するだけでフィードを増やせる
- Fetcherの汎用化: `RSSFetcher`
  - `fetchFeed(def)` と `fetchAllFeeds()` を追加し設定ベースで並列取得
  - `auto` 時はXMLからRSS/Atomを自動判定
  - 既存互換のため `fetchAWSFeed`/`fetchMartinFowlerFeed`/`fetchGitHubChangelogFeed` は薄いラッパーとして残存（テスト互換性維持）
- Cronの共通処理化: `CronHandler`
  - `Object.entries(feeds)` で全ソースを同一ロジック処理
  - 取得件数を `perSourceCounts` に集約してログ出力
- Discordの表示定義を設定参照化: `DiscordNotifier`
  - `displayName` と `color` を `feeds.ts` から参照
- 型の統一: `FeedSource` を導入し `Article.feed_source`/`ArticleFilter.source` に適用

## 影響範囲・互換性

- 既存のテストが依存しているメソッド名（`fetchAWSFeed` 等）はラッパーで維持しているから破壊的変更はなし
- 追加フィードは `feeds.ts` に追記すればCron〜DB保存〜Discord通知まで自動で流れる

## 動作確認

- 型チェック: `npm run type-check`（pass）
- テスト: `bun test`（69 passed / 0 failed）
- デバッグ実行: `bun run scripts/debug-summary.ts`
  - Discordテスト通知が成功
  - 既存3フィード（AWS / Martin Fowler / GitHub Changelog）で記事取得→要約→通知が正常完了

## 追加の運用TIPS

- 一時停止: 一時的に止めたいフィードは `enabled: false`
- 表示/色: Discord埋め込みは `displayName`/`color` を使用（設定のみで変更OK）

## フォローアップ候補（別PR想定）

- フィードごとのレート制限/リトライ（指数バックオフ）
- 取得件数・カテゴリフィルタの設定化
- 通知先Webhookをフィードごとに切り替え（チャンネル分割）
- 重複検出の強化（`guid`/正規化URL/ハッシュ）

## 変更ファイル（主）

- 新規: `src/config/feeds.ts`
- 変更: `src/services/rss-fetcher.ts`、`src/handlers/cron.ts`、`src/services/discord-notifier.ts`、`src/types/index.ts`

## リスク

- 解析の互換性: Atomの `link` 形式（配列/オブジェクト/文字列）を網羅しているが、特殊XMLには追加対応が必要になる可能性あり
- ネットワーク失敗時: `Promise.allSettled` により部分成功で継続、ログで検知（現状の方針を踏襲）

