### PR TITLE
feat: カミナシ開発者ブログのRSS追加とRSSFetcherの汎用API統一 (fetchById/fetchMany)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@
 - 単一責務・疎結合: 取得（`RSSFetcher`）/処理（`CronHandler`）/通知（`DiscordNotifier`）/表示定義（`feeds.ts`）を分離。
 - フォーマット抽象化: RSS/Atom を統一インターフェースでパース。`auto` 指定時はXMLから自動判定。
 - 部分失敗許容: 取得は `Promise.allSettled` で並列実行し、失敗は局所化して継続。件数は `perSourceCounts` としてログ化。
-- 互換性維持: 既存公開メソッド（例: `fetchAWSFeed` など）は薄いラッパーで残し、外部I/Fとエラーメッセージの契約を維持。
+- 互換性維持: デバッグ専用ラッパー（例: `fetchAWSFeed` 等）は廃止し、`fetchById`/`fetchMany` に統一。テスト・スクリプトは `FeedSource` の `id` を指定して呼び出す。
 - 型一貫性: `FeedSource` を設定から導出し、`Article.feed_source` などに適用。
 
 ### 運用手順（フィード追加）

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy:dev": "wrangler deploy",
+    "deploy:prod": "wrangler deploy --env production",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "db:migrate": "wrangler d1 migrations apply rss-summary-db",

--- a/scripts/debug-summary.ts
+++ b/scripts/debug-summary.ts
@@ -75,19 +75,23 @@ async function debugSummary() {
       console.log('⚠️ Discord通知テスト失敗または未設定\n');
     }
 
-    // AWS / Martin Fowler / GitHub Changelog / Kaminashi Developer から記事を取得
+    // 対象フィード（今後はここに追加するだけ）
+    const TARGET_SOURCES: FeedSource[] = [
+      'aws',
+      'martinfowler',
+      'github_changelog',
+      'kaminashi_developer',
+    ];
+
     console.log('📡 RSSフィードから記事を取得中...');
-    const awsArticles = await fetcher.fetchAWSFeed();
-    const fowlerArticles = await fetcher.fetchMartinFowlerFeed();
-    const githubArticles = await fetcher.fetchGitHubChangelogFeed();
-    const kaminashiArticles = await fetcher.fetchKaminashiDeveloperFeed();
-    
+    const results = await fetcher.fetchMany(TARGET_SOURCES);
+
     // 最新の記事を1つずつピックアップ（sourceとセットで保持）
     const testEntries: Array<{ source: FeedSource; article: RSSFeedItem }> = [];
-    if (awsArticles.length > 0) testEntries.push({ source: 'aws', article: awsArticles[0] });
-    if (fowlerArticles.length > 0) testEntries.push({ source: 'martinfowler', article: fowlerArticles[0] });
-    if (githubArticles.length > 0) testEntries.push({ source: 'github_changelog', article: githubArticles[0] });
-    if (kaminashiArticles.length > 0) testEntries.push({ source: 'kaminashi_developer', article: kaminashiArticles[0] });
+    for (const source of TARGET_SOURCES) {
+      const list = results[source] || [];
+      if (list.length > 0) testEntries.push({ source, article: list[0] });
+    }
 
     if (testEntries.length === 0) {
       console.log('❌ テスト用記事が見つかりませんでした');

--- a/scripts/debug-summary.ts
+++ b/scripts/debug-summary.ts
@@ -6,6 +6,7 @@ import { RSSFetcher } from '../src/services/rss-fetcher';
 import { AISummarizer } from '../src/services/ai-summarizer';
 import { DiscordNotifier } from '../src/services/discord-notifier';
 import type { RSSFeedItem, Article } from '../src/types';
+import type { FeedSource } from '../src/config/feeds';
 
 // スクリプト用のシンプルなロガー
 class SimpleLogger {
@@ -74,38 +75,33 @@ async function debugSummary() {
       console.log('⚠️ Discord通知テスト失敗または未設定\n');
     }
 
-    // AWS / Martin Fowler / GitHub Changelog から記事を取得
+    // AWS / Martin Fowler / GitHub Changelog / Kaminashi Developer から記事を取得
     console.log('📡 RSSフィードから記事を取得中...');
     const awsArticles = await fetcher.fetchAWSFeed();
     const fowlerArticles = await fetcher.fetchMartinFowlerFeed();
     const githubArticles = await fetcher.fetchGitHubChangelogFeed();
+    const kaminashiArticles = await fetcher.fetchKaminashiDeveloperFeed();
     
-    // 最新の記事を1つずつピックアップ
-    const testArticles: RSSFeedItem[] = [];
-    
-    if (awsArticles.length > 0) {
-      testArticles.push(awsArticles[0]);
-    }
-    
-    if (fowlerArticles.length > 0) {
-      testArticles.push(fowlerArticles[0]);
-    }
-    if (githubArticles.length > 0) {
-      testArticles.push(githubArticles[0]);
-    }
+    // 最新の記事を1つずつピックアップ（sourceとセットで保持）
+    const testEntries: Array<{ source: FeedSource; article: RSSFeedItem }> = [];
+    if (awsArticles.length > 0) testEntries.push({ source: 'aws', article: awsArticles[0] });
+    if (fowlerArticles.length > 0) testEntries.push({ source: 'martinfowler', article: fowlerArticles[0] });
+    if (githubArticles.length > 0) testEntries.push({ source: 'github_changelog', article: githubArticles[0] });
+    if (kaminashiArticles.length > 0) testEntries.push({ source: 'kaminashi_developer', article: kaminashiArticles[0] });
 
-    if (testArticles.length === 0) {
+    if (testEntries.length === 0) {
       console.log('❌ テスト用記事が見つかりませんでした');
       return;
     }
 
-    console.log(`\n📄 ${testArticles.length}記事をテスト対象として選択\n`);
+    console.log(`\n📄 ${testEntries.length}記事をテスト対象として選択\n`);
 
     // 各記事の要約を生成してテスト
-    for (let i = 0; i < testArticles.length; i++) {
-      const article = testArticles[i];
+    for (let i = 0; i < testEntries.length; i++) {
+      const { source, article } = testEntries[i];
       
       console.log(`--- 記事 ${i + 1} ---`);
+      console.log(`🟦 ソース: ${source}`);
       console.log(`📰 タイトル: ${article.title}`);
       console.log(`🔗 URL: ${article.url}`);
       console.log(`📅 公開日: ${article.published_date}`);
@@ -144,7 +140,7 @@ async function debugSummary() {
             title: article.title,
             url: article.url,
             published_date: article.published_date,
-            feed_source: i === 0 ? 'aws' : (i === 1 ? 'martinfowler' : 'github_changelog'),
+            feed_source: source,
             original_content: article.content || '',
             summary_ja: summary,
             created_at: new Date().toISOString(),

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -35,6 +35,14 @@ export const FEEDS = [
     color: 0x6e5494,
     enabled: true,
   },
+  {
+    id: 'kaminashi_developer',
+    url: 'https://kaminashi-developer.hatenablog.jp/rss',
+    format: 'auto',
+    displayName: 'カミナシ開発者ブログ',
+    color: 0x1abc9c,
+    enabled: true,
+  },
 ] as const satisfies ReadonlyArray<FeedDefinition>;
 
 export type FeedSource = typeof FEEDS[number]['id'];
@@ -42,4 +50,3 @@ export type FeedSource = typeof FEEDS[number]['id'];
 export function getFeedById(id: string): FeedDefinition | undefined {
   return (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === id);
 }
-

--- a/src/services/rss-fetcher.ts
+++ b/src/services/rss-fetcher.ts
@@ -42,53 +42,34 @@ export class RSSFetcher {
     return map;
   }
 
-  // 後方互換: 既存テストと呼び出しのためのラッパー
-  async fetchAWSFeed(): Promise<RSSFeedItem[]> {
-    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === 'aws');
+  async fetchById(id: FeedSource): Promise<RSSFeedItem[]> {
+    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === id);
     if (!def) return [];
     try {
       return await this.fetchFeed(def);
     } catch (e) {
       const m = e instanceof Error ? e.message : String(e);
       const reason = m.includes(':') ? m.split(':').slice(1).join(':').trim() : m;
-      throw new Error(`Failed to fetch AWS RSS feed: ${reason}`);
+      throw new Error(`Failed to fetch ${id} feed: ${reason}`);
     }
   }
 
-  async fetchMartinFowlerFeed(): Promise<RSSFeedItem[]> {
-    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === 'martinfowler');
-    if (!def) return [];
-    try {
-      return await this.fetchFeed(def);
-    } catch (e) {
-      const m = e instanceof Error ? e.message : String(e);
-      const reason = m.includes(':') ? m.split(':').slice(1).join(':').trim() : m;
-      throw new Error(`Failed to fetch Martin Fowler Atom feed: ${reason}`);
-    }
-  }
+  async fetchMany(ids: ReadonlyArray<FeedSource>): Promise<Record<FeedSource, RSSFeedItem[]>> {
+    const selected = (FEEDS as ReadonlyArray<FeedDefinition>).filter((f) => ids.includes(f.id as FeedSource));
+    const results = await Promise.allSettled(
+      selected.map(async (def) => ({ id: def.id as FeedSource, items: await this.fetchFeed(def) }))
+    );
 
-  async fetchGitHubChangelogFeed(): Promise<RSSFeedItem[]> {
-    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === 'github_changelog');
-    if (!def) return [];
-    try {
-      return await this.fetchFeed(def);
-    } catch (e) {
-      const m = e instanceof Error ? e.message : String(e);
-      const reason = m.includes(':') ? m.split(':').slice(1).join(':').trim() : m;
-      throw new Error(`Failed to fetch GitHub Changelog RSS feed: ${reason}`);
+    const map = Object.create(null) as Record<FeedSource, RSSFeedItem[]>;
+    for (const id of ids) {
+      map[id] = [];
     }
-  }
-
-  async fetchKaminashiDeveloperFeed(): Promise<RSSFeedItem[]> {
-    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === 'kaminashi_developer');
-    if (!def) return [];
-    try {
-      return await this.fetchFeed(def);
-    } catch (e) {
-      const m = e instanceof Error ? e.message : String(e);
-      const reason = m.includes(':') ? m.split(':').slice(1).join(':').trim() : m;
-      throw new Error(`Failed to fetch Kaminashi Developer feed: ${reason}`);
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        map[r.value.id] = r.value.items;
+      }
     }
+    return map;
   }
 
   private detectFormat(xmlText: string): 'rss' | 'atom' {

--- a/src/services/rss-fetcher.ts
+++ b/src/services/rss-fetcher.ts
@@ -79,6 +79,18 @@ export class RSSFetcher {
     }
   }
 
+  async fetchKaminashiDeveloperFeed(): Promise<RSSFeedItem[]> {
+    const def = (FEEDS as ReadonlyArray<FeedDefinition>).find((f) => f.id === 'kaminashi_developer');
+    if (!def) return [];
+    try {
+      return await this.fetchFeed(def);
+    } catch (e) {
+      const m = e instanceof Error ? e.message : String(e);
+      const reason = m.includes(':') ? m.split(':').slice(1).join(':').trim() : m;
+      throw new Error(`Failed to fetch Kaminashi Developer feed: ${reason}`);
+    }
+  }
+
   private detectFormat(xmlText: string): 'rss' | 'atom' {
     const normalized = xmlText.toLowerCase();
     if (normalized.includes('<feed') && normalized.includes('<entry')) return 'atom';

--- a/tests/services/rss-fetcher.test.ts
+++ b/tests/services/rss-fetcher.test.ts
@@ -12,7 +12,7 @@ describe('RSSFetcher', () => {
     rssFetcher = new RSSFetcher();
   });
 
-  describe('fetchAWSFeed', () => {
+  describe('fetchById(aws)', () => {
     it('should fetch and parse AWS RSS feed', async () => {
       const mockRSSXML = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -32,7 +32,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve(mockRSSXML)
       });
 
-      const result = await rssFetcher.fetchAWSFeed();
+      const result = await rssFetcher.fetchById('aws');
 
       expect(mockFetch).toHaveBeenCalledWith('https://aws.amazon.com/about-aws/whats-new/recent/feed/');
       expect(result).toHaveLength(1);
@@ -47,7 +47,7 @@ describe('RSSFetcher', () => {
     it('should handle fetch errors gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
-      await expect(rssFetcher.fetchAWSFeed()).rejects.toThrow('Failed to fetch AWS RSS feed: Network error');
+      await expect(rssFetcher.fetchById('aws')).rejects.toThrow('Failed to fetch aws feed: Network error');
     });
 
     it('should handle invalid RSS XML', async () => {
@@ -56,7 +56,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve('Invalid XML')
       });
 
-      await expect(rssFetcher.fetchAWSFeed()).rejects.toThrow('Failed to parse RSS feed');
+      await expect(rssFetcher.fetchById('aws')).rejects.toThrow(/Failed to parse RSS feed/);
     });
 
     it('should handle empty RSS feed', async () => {
@@ -72,12 +72,12 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve(emptyRSSXML)
       });
 
-      const result = await rssFetcher.fetchAWSFeed();
+      const result = await rssFetcher.fetchById('aws');
       expect(result).toEqual([]);
     });
   });
 
-  describe('fetchMartinFowlerFeed', () => {
+  describe('fetchById(martinfowler)', () => {
     it('should fetch and parse Martin Fowler Atom feed', async () => {
       const mockAtomXML = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -95,7 +95,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve(mockAtomXML)
       });
 
-      const result = await rssFetcher.fetchMartinFowlerFeed();
+      const result = await rssFetcher.fetchById('martinfowler');
 
       expect(mockFetch).toHaveBeenCalledWith('https://martinfowler.com/feed.atom');
       expect(result).toHaveLength(1);
@@ -110,7 +110,7 @@ describe('RSSFetcher', () => {
     it('should handle fetch errors gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
-      await expect(rssFetcher.fetchMartinFowlerFeed()).rejects.toThrow('Failed to fetch Martin Fowler Atom feed: Network error');
+      await expect(rssFetcher.fetchById('martinfowler')).rejects.toThrow('Failed to fetch martinfowler feed: Network error');
     });
 
     it('should handle invalid Atom XML', async () => {
@@ -119,7 +119,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve('Invalid XML')
       });
 
-      await expect(rssFetcher.fetchMartinFowlerFeed()).rejects.toThrow('Failed to parse Atom feed');
+      await expect(rssFetcher.fetchById('martinfowler')).rejects.toThrow(/Failed to parse Atom feed/);
     });
 
     it('should parse Martin Fowler Atom feed with updated field', async () => {
@@ -145,7 +145,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve(mockAtomXML)
       });
 
-      const result = await rssFetcher.fetchMartinFowlerFeed();
+      const result = await rssFetcher.fetchById('martinfowler');
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
@@ -157,7 +157,7 @@ describe('RSSFetcher', () => {
     });
   });
 
-  describe('fetchGitHubChangelogFeed', () => {
+  describe('fetchById(github_changelog)', () => {
     it('should fetch and parse GitHub Changelog RSS feed', async () => {
       const mockRSSXML = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -176,7 +176,7 @@ describe('RSSFetcher', () => {
         text: () => Promise.resolve(mockRSSXML)
       });
 
-      const result = await rssFetcher.fetchGitHubChangelogFeed();
+      const result = await rssFetcher.fetchById('github_changelog');
 
       expect(mockFetch).toHaveBeenCalledWith('https://github.blog/changelog/feed/');
       expect(result).toHaveLength(1);
@@ -190,7 +190,7 @@ describe('RSSFetcher', () => {
 
     it('should handle fetch errors gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
-      await expect(rssFetcher.fetchGitHubChangelogFeed()).rejects.toThrow('Failed to fetch GitHub Changelog RSS feed: Network error');
+      await expect(rssFetcher.fetchById('github_changelog')).rejects.toThrow('Failed to fetch github_changelog feed: Network error');
     });
   });
 


### PR DESCRIPTION
## 目的
- カミナシ開発者ブログ (https://kaminashi-developer.hatenablog.jp/rss)を新規フィードとして追加する。
- `RSSFetcher` にデバッグ用の個別ラッパーを増やさず、汎用API（`fetchById` / `fetchMany`）に統一して保守性を上げる。

## 変更内容
- config: `src/config/feeds.ts`
  - `kaminashi_developer` を追加（`format: 'auto'`, `displayName: 'カミナシ開発者ブログ'`, `enabled: true`）。
- fetcher: `src/services/rss-fetcher.ts`
  - 追加: `fetchById(id: FeedSource)` / `fetchMany(ids: FeedSource[])`。
  - 削除: デバッグ用途の専用メソッド（`fetchAWSFeed` / `fetchMartinFowlerFeed` / `fetchGitHubChangelogFeed` / `fetchKaminashiDeveloperFeed`）。
  - 例外メッセージを `<id>` ベースに統一（例: `Failed to fetch <id> feed: ...`）。
- debug: `scripts/debug-summary.ts`
  - `TARGET_SOURCES` に `kaminashi_developer` を追加し、`fetchMany()` で一括取得する実装に変更。
- tests: `tests/services/rss-fetcher.test.ts`
  - 既存テストを `fetchById()` 呼び出しに置換。エラーメッセージの期待値を汎用メッセージに合わせて調整。
- docs: `AGENTS.md`
  - 方針更新（デバッグ専用ラッパーは廃止し、`fetchById` / `fetchMany` を使用）。

## 動作確認
- 型チェック
  ```bash
  bun run type-check
  ```
- テスト（ローカル）
  ```bash
  bun test
  # 結果: 69 pass / 0 fail（手元で確認済み）
  ```
- Lint
  ```bash
  bun run lint
  ```
- デバッグ実行（通知OFFで安全に）
  ```bash
  DISCORD_WEBHOOK_URL='' bun run scripts/debug-summary.ts
  ```
  - `GEMINI_API_KEY` は `.dev.vars` または `wrangler secret` で設定。

## リリース影響
- 既存の定期取得/要約/Discord通知フローに影響なし（新フィードが追加されるのみ）。
- 例外メッセージの文言が一部統一されますが、外部I/Fの互換性を壊しません。

## ロールバック
- `src/config/feeds.ts` の `kaminashi_developer` を `enabled: false` にする、またはこのPRのRevertで戻せます。

## 関連
- なし（必要なら追記）
