### PR TITLE
Add Tidy First feed and improve RSS content extraction

### DIFF
--- a/scripts/debug-summary.ts
+++ b/scripts/debug-summary.ts
@@ -81,6 +81,7 @@ async function debugSummary() {
       'martinfowler',
       'github_changelog',
       'kaminashi_developer',
+      'tidyfirst',
     ];
 
     console.log('📡 RSSフィードから記事を取得中...');

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -43,6 +43,14 @@ export const FEEDS = [
     color: 0x1abc9c,
     enabled: true,
   },
+  {
+    id: 'tidyfirst',
+    url: 'https://tidyfirst.substack.com/feed',
+    format: 'rss',
+    displayName: 'Tidy First?',
+    color: 0xe67e22,
+    enabled: true,
+  },
 ] as const satisfies ReadonlyArray<FeedDefinition>;
 
 export type FeedSource = typeof FEEDS[number]['id'];

--- a/tests/services/rss-fetcher.test.ts
+++ b/tests/services/rss-fetcher.test.ts
@@ -75,6 +75,33 @@ describe('RSSFetcher', () => {
       const result = await rssFetcher.fetchById('aws');
       expect(result).toEqual([]);
     });
+
+    it('should prefer content:encoded over description when present', async () => {
+      const htmlBody = '<p>Full article body</p>';
+      const mockRSSXML = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<channel>
+<title>AWS What's New</title>
+<item>
+<title>AWS announces new feature</title>
+<link>https://aws.amazon.com/about-aws/whats-new/2024/01/aws-new-feature/</link>
+<pubDate>Mon, 01 Jan 2024 10:00:00 GMT</pubDate>
+<description>A short teaser</description>
+<content:encoded><![CDATA[${htmlBody}]]></content:encoded>
+</item>
+</channel>
+</rss>`;
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockRSSXML)
+      });
+
+      const result = await rssFetcher.fetchById('aws');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toBe(htmlBody);
+    });
   });
 
   describe('fetchById(martinfowler)', () => {


### PR DESCRIPTION
## Summary
- add tidyfirst Substack feed config and include it in debug summary targets
- prefer RSS content:encoded or content elements so Substack articles keep full bodies
- cover the new parser behaviour with unit tests and verify end-to-end via debug summary

## Testing
- bun run lint
- bun run type-check
- bun test
- bunx wrangler deploy
- bun run scripts/debug-summary.ts
